### PR TITLE
fixes for  backend/sr/db.js, readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ Full functional Wix clone created in React, express and MongoDB. Has drag drop f
    `API_MONGO_URI="[ REMOVED FROM THE CODE ]"`<br/>
    `API_MONGO_PASS="[ MONGODB PASSWORD ]"`<br/>
    `API_MONGO_USER="[ MONGO DB NAME ]"`<br/>
+   `API_MONGO_LOCATION="[ mongodb for local instance, mongodb+srv for remote "]`<br/>
 5. `npm run dev` to run on a local machine. For deployment use `node ./src/server.js`
 6. It should be available on the port 8000.

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -3,7 +3,8 @@ import { MongoClient } from 'mongodb';
 let client;
 
 export const initializeDbConnection = async () => {
-    client = await MongoClient.connect(`mongodb+srv://${process.env.API_MONGO_USER}:${process.env.API_MONGO_PASS}@cluster0.xkeckso.mongodb.net/?retryWrites=true&w=majority`, {
+    client = await MongoClient.connect(`${process.env.API_MONGO_LOCATION}://${process.env.API_MONGO_USER}:${process.env.API_MONGO_PASS}`
+        +`@${process.env.API_MONGO_URI}/${process.env.API_DB_NAME}?retryWrites=true&w=majority`, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
     });


### PR DESCRIPTION
URI for the mongo cluster used for development was in /backend/src/db.js file.  I took that out, and added one config value show in readme.   Now entire connection string is built from configured values.  Have tested this with 
API_MONGO_LOCATION="mongodb"
and local dev environment.